### PR TITLE
Marked is active

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
     "klipse-github-docs-generator": "./klipse-github-docs-generator"
   },
   "dependencies": {
-    "8fold-marked": "^0.3.9"
+    "marked": "^0.3.18"
   }
 }


### PR DESCRIPTION
Given the scope of the PR - contributing guidelines weren't checked. Apologies if there is a missed convention.

[Marked](https://github.com/markedjs/marked) is in an active status again.

As part of due diligence I going around making sure project dependent on the `8fold-marked` workaround are updated. We have fixed a few defects including another discovered security vulnerability.